### PR TITLE
Add top menu

### DIFF
--- a/src/app/layouts/private-layout/private-layout.component.html
+++ b/src/app/layouts/private-layout/private-layout.component.html
@@ -1,4 +1,4 @@
-<!-- <app-header></app-header> --> <!-- Przykładowy nagłówek -->
+<app-top-menu></app-top-menu>
 
 <div class="main-container">
   <!-- <app-sidebar></app-sidebar> --> <!-- Przykładowe menu boczne -->

--- a/src/app/layouts/private-layout/private-layout.component.ts
+++ b/src/app/layouts/private-layout/private-layout.component.ts
@@ -1,16 +1,13 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-// Możesz tu zaimportować komponenty nagłówka, stopki, nawigacji itp.
-// import { HeaderComponent } from '../../shared/header/header.component';
-// import { SidebarComponent } from '../../shared/sidebar/sidebar.component';
+import { TopMenuComponent } from '../../shared/top-menu.component';
 
 @Component({
   selector: 'app-private-layout',
   standalone: true,
   imports: [
     RouterOutlet,
-    // HeaderComponent, // Dodaj importy potrzebnych elementów UI
-    // SidebarComponent
+    TopMenuComponent
   ],
   templateUrl: './private-layout.component.html',
   styleUrls: ['./private-layout.component.scss']

--- a/src/app/layouts/public-layout/public-layout.component.html
+++ b/src/app/layouts/public-layout/public-layout.component.html
@@ -1,1 +1,2 @@
+<app-top-menu></app-top-menu>
 <router-outlet></router-outlet>

--- a/src/app/layouts/public-layout/public-layout.component.ts
+++ b/src/app/layouts/public-layout/public-layout.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { TopMenuComponent } from '../../shared/top-menu.component';
 
 @Component({
   selector: 'app-public-layout',
   standalone: true,
-  imports: [RouterOutlet],
-  template: '<router-outlet></router-outlet>', // Tylko outlet dla treści (np. LoginComponent)
+  imports: [RouterOutlet, TopMenuComponent],
+  templateUrl: './public-layout.component.html',
   styleUrls: ['./public-layout.component.scss']
 })
 export class PublicLayoutComponent { }

--- a/src/app/shared/top-menu.component.html
+++ b/src/app/shared/top-menu.component.html
@@ -1,0 +1,10 @@
+<nav class="bg-indigo-600 text-white p-4">
+  <ul class="flex justify-center space-x-6">
+    <li>
+      <a routerLink="/login" routerLinkActive="font-bold underline" class="hover:underline">Logowanie</a>
+    </li>
+    <li>
+      <a routerLink="/invoices" routerLinkActive="font-bold underline" class="hover:underline">Faktury</a>
+    </li>
+  </ul>
+</nav>

--- a/src/app/shared/top-menu.component.ts
+++ b/src/app/shared/top-menu.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-top-menu',
+  standalone: true,
+  imports: [RouterModule],
+  templateUrl: './top-menu.component.html'
+})
+export class TopMenuComponent {}


### PR DESCRIPTION
## Summary
- add standalone top menu component
- include top menu in private and public layouts for navigation

## Testing
- `npm run lint` *(fails: `npm` not found)*